### PR TITLE
Gateway Refactory

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -4,88 +4,109 @@ package main
  * File: gateway.go
  *
  * The gateway is the main processing center for NBA. This is where the decisions
- * are made on which alerts are proxied, cached, discarded, set OK, etc.
+ * are made on which alerts are proxied, cached, discarded, set OK, etc. The Gateway
+ * works by listening to a series of events. Current events that are listened to include:
+ *
+ *  - NSCA message received from client
+ *  - StateExpiry event received from registry
+ *  - InitBufferExpiry event received from registry
  */
+
+import (
+	"sync"
+)
 
 // Gateway is where all the messages flow through
 type Gateway struct {
-	registry            *Registry
-	incomingMessageChan chan *Message
+	registry          *Registry
+	incomingEventChan chan *GatewayEvent
+	startOnce         sync.Once
+}
+
+// GatewayEvent represents union of events a Gateway expects to receive
+type GatewayEvent struct {
+	message          *Message
+	stateExpiry      *StateExpiry
+	initBufferExpiry *InitBufferExpiry
 }
 
 /**
- * Initiates the gateway that listens and processes messages.
+ * Initiates the gateway that listens and processes various types of events.
  */
 func (g *Gateway) run() {
-	// setup subscription channel for registry timeout notifications
-	go g.handleExpiry(g.registry.expireChan)
-
-	// handle all incoming (new messages) from clients
-	go g.handleIncomingMessages(g.incomingMessageChan)
+	g.startOnce.Do(func() {
+		go g.handleIncomingEvents(g.incomingEventChan)
+	})
 }
 
 /**
  * Listen specificially for incoming messages and process them.
  */
-func (g *Gateway) handleIncomingMessages(ch chan *Message) {
+func (g *Gateway) handleIncomingEvents(ch chan *GatewayEvent) {
 	for {
-		message := <-ch
-		if oldMessage := g.registry.get(message.Service); oldMessage != nil {
-			if message.State > oldMessage.State {
-				// TODO things got worse, what now?
-				// send upstream
-				Logger().Info.Printf("PUSH Sending state '%s' for '%s' upstream",
-					stateName(message.State), message.Service)
-			} else if message.State < oldMessage.State {
-				// TODO things got better, what now?
-				// send upstream
-				Logger().Info.Printf("PUSH Sending state '%s' for '%s' upstream",
-					stateName(message.State), message.Service)
-			} else {
-				// it's the same... so we're not gonna do anything but buffer the
-				// message to the TTLs can be updated and what not
-				Logger().Trace.Printf("HOLD Duplicate message for service: %s\n", message.Service)
+		event := <-ch
+		if event == nil {
+			continue
+		}
+		if event.message != nil {
+			/*
+			 * The event is an incoming message. All incoming messages should be buffered for a small
+			 * period of time to make sure we're not thrashing (flip-flopping).
+			 */
+			// TODO a flood of duplicate states will continually push back buffer-init-ttl, meaning no messages sent.
+			//      figure a good way to handle duplicates / flooding
+			g.registry.update(event.message)
+			Logger().Trace.Printf("registry:\n%s\n", g.registry.summaryString())
+		} else if event.initBufferExpiry != nil {
+			/*
+			 * All messages are given an initial buffering time. This event is raised when that time is up.
+			 * At this point we need to make a decision based on the sate of the message. In general we do:
+			 *   - if previous state is different, proxy
+			 *   - if previous state is the same, do nothing
+			 *   - if previous state does not exist (expired or new), proxy
+			 */
+			if message := g.registry.get(event.initBufferExpiry.service); message != nil {
+				if previous := g.registry.getPrev(event.initBufferExpiry.service); previous != nil {
+					if message.State != previous.State {
+						Logger().Info.Printf("detected state change from %s to %s for service %s",
+							stateName(previous.State), stateName(message.State), message.Service)
+					}
+				} else {
+					Logger().Info.Printf("new state of %s for service %s, sending upstream",
+						stateName(message.State), message.Service)
+				}
 			}
-		} else {
-			Logger().Trace.Printf("PUSH-NEW Sending state '%s' for '%s' upstream",
-				stateName(message.State), message.Service)
-		}
-		g.registry.update(message)
-		Logger().Trace.Printf("registry:\n%s\n", g.registry.summaryString())
-	}
-}
-
-/**
- * Listen for messages that are expiring from the registry and take action. An expired message
- * is really just the last provided state for a a service / alert. If it's in an error or warning
- * state, then we may want to clear the event. If it's in an OK state, we can leave it be.
- */
-func (g *Gateway) handleExpiry(expireNotificationChan chan *Message) {
-	for {
-		message := <-expireNotificationChan
-		Logger().Info.Printf("expired message: %v with state %s\n", message, stateName(message.State))
-		if message.State == stateOk {
-
-		}
-		switch message.State {
-		case stateOk:
-			// do nothing
-		case stateWarning:
-			fallthrough
-		case stateCritical:
-			// TODO clear the state to the upstream nagios server
-			Logger().Info.Printf("PUSH Sending state '%s' for expired service '%s' upstream",
-				stateName(stateOk), message.Service)
-		default:
-			Logger().Trace.Println("Expired message in UNKNOWN state")
+		} else if event.stateExpiry != nil {
+			/*
+			 * An alert is cached based on it's last recorded state. When a service has not had any activity
+			 * in a while, it will eventually expire with it's last known state. That is when this event is raised
+			 * and we can take action on it. If an event expires in an error-state, we can set it back to a
+			 * non-error state.
+			 *
+			 * TODO determine what the non-error state should be (OK?, WARN?, configurable?)
+			 */
+			if message := g.registry.get(event.stateExpiry.service); message != nil {
+				Logger().Info.Printf("expired message: %v with state %s\n", message, stateName(message.State))
+				switch message.State {
+				case stateOk: // do nothing
+				case stateWarning:
+					fallthrough
+				case stateCritical:
+					// TODO clear the state to the upstream nagios server
+					Logger().Info.Printf("PUSH Sending state '%s' for expired service '%s' upstream",
+						stateName(stateOk), message.Service)
+				default:
+					Logger().Trace.Println("Expired message in UNKNOWN state")
+				}
+			}
 		}
 	}
 }
 
-func newGateway(r *Registry, incomingMessageChan chan *Message) *Gateway {
+func newGateway(r *Registry, incomingEventChan chan *GatewayEvent) *Gateway {
 	g := &Gateway{
-		registry:            r,
-		incomingMessageChan: incomingMessageChan,
+		registry:          r,
+		incomingEventChan: incomingEventChan,
 	}
 	return g
 }


### PR DESCRIPTION
I really want to put most of the "business logic" into one place with
te gateway. Also, I was doing some GoLang no-no's by having multiple
writers to a shared map with the registry and gateway. This puts everything
back into the gateway and makes the registry just a specialized cache.

There is still more work to do with figuring out how to organize logic
between the registry and the gateway (maybe they just belong in the same
set of stuffs??), but things are looking much better.
