### PR TITLE
remove gateway race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5
+  - 1.6
   - tip
 
 install: make get-deps

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILD_OPTS=-p 4
+BUILD_OPTS=-p 4 -race
 BIN_NAME=nbad
 
 default: compile

--- a/gateway.go
+++ b/gateway.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"sync"
+	"time"
 )
 
 // Gateway is where all the messages flow through
@@ -30,6 +31,12 @@ type GatewayEvent struct {
 	initBufferExpiry *InitBufferExpiry
 }
 
+// StateExpiry is an event raised when the current service state expires (no recent message)
+type StateExpiry struct{ service string }
+
+// InitBufferExpiry is an event raised when buffering of initial server state has been reached
+type InitBufferExpiry struct{ service string }
+
 /**
  * Initiates the gateway that listens and processes various types of events.
  */
@@ -39,69 +46,90 @@ func (g *Gateway) run() {
 	})
 }
 
-/**
- * Listen specificially for incoming messages and process them.
- */
+// handleIncomingEvents - listen for incoming events and dispatch them to the appropriate handling code
 func (g *Gateway) handleIncomingEvents(ch chan *GatewayEvent) {
+	tick := time.Tick(100 * time.Millisecond)
 	for {
-		event := <-ch
-		if event == nil {
-			continue
-		}
-		if event.message != nil {
-			/*
-			 * The event is an incoming message. All incoming messages should be buffered for a small
-			 * period of time to make sure we're not thrashing (flip-flopping). However we have to be careful
-			 * so that a flooding scenario doesn't cause us to stall indefinitely. Thus the following rules
-			 * can be applied:
-			 *   - if no previous service alert, store
-			 *   - if previous service alert with same state (OK, WARN, etc), discard current message, update no TTLs
-			 *   - if previous service alert is different, update message and all TTLs
-			 */
-			// TODO - Update logic to reflect above description
-			g.registry.update(event.message)
-			Logger().Trace.Printf("registry:\n%s\n", g.registry.summaryString())
-		} else if event.initBufferExpiry != nil {
-			/*
-			 * All messages are given an initial buffering time. This event is raised when that time is up.
-			 * At this point we need to make a decision based on the sate of the message. In general we do:
-			 *   - if previous state is different, proxy
-			 *   - if previous state is the same, do nothing
-			 *   - if previous state does not exist (expired or new), proxy
-			 */
-			if message := g.registry.get(event.initBufferExpiry.service); message != nil {
-				if previous := g.registry.getPrev(event.initBufferExpiry.service); previous != nil {
-					if message.State != previous.State {
-						Logger().Info.Printf("detected state change from %s to %s for service %s",
-							stateName(previous.State), stateName(message.State), message.Service)
-					}
-				} else {
-					Logger().Info.Printf("new state of %s for service %s, sending upstream",
-						stateName(message.State), message.Service)
-				}
+		select {
+		case <-tick:
+			g.expireOldMessages(g.incomingEventChan)
+		case event := <-ch:
+			if event == nil {
+				continue
 			}
-		} else if event.stateExpiry != nil {
-			/*
-			 * An alert is cached based on it's last recorded state. When a service has not had any activity
-			 * in a while, it will eventually expire with it's last known state. That is when this event is raised
-			 * and we can take action on it. If an event expires in an error-state, we can set it back to a
-			 * non-error state.
-			 *
-			 * TODO determine what the non-error state should be (OK?, WARN?, configurable?)
-			 */
-			if message := g.registry.get(event.stateExpiry.service); message != nil {
-				Logger().Info.Printf("expired message: %v with state %s\n", message, stateName(message.State))
-				switch message.State {
-				case stateOk: // do nothing
-				case stateWarning:
-					fallthrough
-				case stateCritical:
-					// TODO clear the state to the upstream nagios server
-					Logger().Info.Printf("PUSH Sending state '%s' for expired service '%s' upstream",
-						stateName(stateOk), message.Service)
-				default:
-					Logger().Trace.Println("Expired message in UNKNOWN state")
+			g.handleMessageStateChange(event)
+		}
+	}
+}
+
+// expireOldMessages - scan registry and emit events for message expirations
+func (g *Gateway) expireOldMessages(ch chan *GatewayEvent) {
+	now := time.Now()
+	for _, v := range g.registry.cache {
+		if now.After(v.expireAt) {
+			// send notification of message expiration
+			ch <- &GatewayEvent{stateExpiry: &StateExpiry{service: v.message.Service}}
+		} else if now.After(v.initBufferExpireAt) {
+			// send notification of init-buffer expiry
+			ch <- &GatewayEvent{initBufferExpiry: &InitBufferExpiry{service: v.message.Service}}
+		}
+	}
+}
+
+func (g *Gateway) handleMessageStateChange(event *GatewayEvent) {
+	if event.message != nil {
+		/*
+		 * The event is an incoming message. All incoming messages should be buffered for a small
+		 * period of time to make sure we're not thrashing (flip-flopping). However we have to be careful
+		 * so that a flooding scenario doesn't cause us to stall indefinitely. Thus the following rules
+		 * can be applied:
+		 *   - if no previous service alert, store
+		 *   - if previous service alert with same state (OK, WARN, etc), discard current message, update no TTLs
+		 *   - if previous service alert is different, update message and all TTLs
+		 */
+		// TODO - Update logic to reflect above description
+		g.registry.update(event.message)
+		Logger().Trace.Printf("registry:\n%s\n", g.registry.summaryString())
+	} else if event.initBufferExpiry != nil {
+		/*
+		 * All messages are given an initial buffering time. This event is raised when that time is up.
+		 * At this point we need to make a decision based on the sate of the message. In general we do:
+		 *   - if previous state is different, proxy
+		 *   - if previous state is the same, do nothing
+		 *   - if previous state does not exist (expired or new), proxy
+		 */
+		if message := g.registry.get(event.initBufferExpiry.service); message != nil {
+			if previous := g.registry.getPrev(event.initBufferExpiry.service); previous != nil {
+				if message.State != previous.State {
+					Logger().Info.Printf("detected state change from %s to %s for service %s",
+						stateName(previous.State), stateName(message.State), message.Service)
 				}
+			} else {
+				Logger().Info.Printf("new state of %s for service %s, sending upstream",
+					stateName(message.State), message.Service)
+			}
+		}
+	} else if event.stateExpiry != nil {
+		/*
+		 * An alert is cached based on it's last recorded state. When a service has not had any activity
+		 * in a while, it will eventually expire with it's last known state. That is when this event is raised
+		 * and we can take action on it. If an event expires in an error-state, we can set it back to a
+		 * non-error state.
+		 *
+		 * TODO determine what the non-error state should be (OK?, WARN?, configurable?)
+		 */
+		if message := g.registry.get(event.stateExpiry.service); message != nil {
+			Logger().Info.Printf("expired message: %v with state %s\n", message, stateName(message.State))
+			switch message.State {
+			case stateOk: // do nothing
+			case stateWarning:
+				fallthrough
+			case stateCritical:
+				// TODO clear the state to the upstream nagios server
+				Logger().Info.Printf("PUSH Sending state '%s' for expired service '%s' upstream",
+					stateName(stateOk), message.Service)
+			default:
+				Logger().Trace.Println("Expired message in UNKNOWN state")
 			}
 		}
 	}


### PR DESCRIPTION
this removes the need for the registry to have it's own go-routine that
handles cache expiry. now the registry code is a simple cache wrapper/abstraction
that doesn't have any go-routines associated with it. cache expiration is
now handled by the gateway (as it should be).
